### PR TITLE
pkg/metrics: fix bug in reset

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -74,7 +74,6 @@ type Gauge interface {
 type Histogram interface {
 	With(labelValues ...string) Histogram
 	Observe(value float64)
-	Reset()
 }
 
 // CounterAdd increases the passed in counter by the amount specified.
@@ -173,12 +172,4 @@ func HistogramWith(h Histogram, labelValues ...string) Histogram {
 		return nil
 	}
 	return h.With(labelValues...)
-}
-
-// HistogramReset resets the passed in histogram.
-// This is a no-op if h is nil.
-func HistogramReset(h Histogram) {
-	if h != nil {
-		h.Reset()
-	}
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -122,7 +122,7 @@ func (g *gauge) Add(delta float64) {
 
 // Reset deletes all metrics in this vector.
 func (g *gauge) Reset() {
-	g.gv.Reset()
+	g.gv.MustCurryWith(makeLabels(g.lvs...)).Reset()
 }
 
 // newGauge wraps the GaugeVec and returns a usable Gauge object.
@@ -168,7 +168,7 @@ func (c *counter) Add(delta float64) {
 
 // Reset deletes all metrics in this vector.
 func (c *counter) Reset() {
-	c.cv.Reset()
+	c.cv.MustCurryWith(makeLabels(c.lvs...)).Reset()
 }
 
 // histogram implements Histogram via a Prometheus HistogramVec. The difference
@@ -205,11 +205,6 @@ func (h *histogram) With(labelValues ...string) Histogram {
 // Observe implements Histogram.
 func (h *histogram) Observe(value float64) {
 	h.hv.With(makeLabels(h.lvs...)).Observe(value)
-}
-
-// Reset deletes all metrics in this vector.
-func (h *histogram) Reset() {
-	h.hv.Reset()
 }
 
 func makeLabels(labelValues ...string) prometheus.Labels {


### PR DESCRIPTION
Reset deleted all the timeseries irrespective of the labels set. With this patch only the timeseries matching the labels are reset.

Reset for histograms is removed as prometheus client does not implement reset on ObserverVec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/2)
<!-- Reviewable:end -->
