### PR TITLE
PATCH: patches/com_github_scionproto_scion/reliable_re-use_metrics.patch

### DIFF
--- a/pkg/sock/reliable/internal/metrics/BUILD.bazel
+++ b/pkg/sock/reliable/internal/metrics/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//pkg/sock/reliable:__subpackages__"],
     deps = [
         "//pkg/private/prom:go_default_library",
+        "//pkg/private/serrors:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
     ],
 )

--- a/pkg/sock/reliable/reliable.go
+++ b/pkg/sock/reliable/reliable.go
@@ -266,7 +266,7 @@ func registrationExchange(conn *Conn, reg *Registration) (uint16, error) {
 // (usually, the border router) which sent the message.
 func (conn *Conn) ReadFrom(buf []byte) (int, net.Addr, error) {
 	n, addr, err := conn.readFrom(buf)
-	metrics.M.Reads(metrics.IOLabels{Result: labelResult(err)}).Observe(float64(n))
+	metrics.M.Reads(err).Observe(float64(n))
 	return n, addr, err
 }
 
@@ -302,7 +302,7 @@ func (conn *Conn) readFrom(buf []byte) (int, net.Addr, error) {
 // is always len(buf).
 func (conn *Conn) WriteTo(buf []byte, dst net.Addr) (int, error) {
 	n, err := conn.writeTo(buf, dst)
-	metrics.M.Writes(metrics.IOLabels{Result: labelResult(err)}).Observe(float64(n))
+	metrics.M.Writes(err).Observe(float64(n))
 	return n, err
 }
 


### PR DESCRIPTION
Instead of continuously calling WithLabelValues on each observation only do it once on initialization. This can have an impact on performance if a lot of reliable packets are sent.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/5)
<!-- Reviewable:end -->
