### PR TITLE
PATCH: patches/com_github_scionproto_scion/simpler_metrics.patch

### DIFF
--- a/control/observability.go
+++ b/control/observability.go
@@ -81,7 +81,7 @@ type Metrics struct {
 	TrustTRCFileWritesTotal                *prometheus.CounterVec
 	SCIONNetworkMetrics                    snet.SCIONNetworkMetrics
 	SCIONPacketConnMetrics                 snet.SCIONPacketConnMetrics
-	SCMPErrors                             metrics.Counter
+	SCMPErrors                             metrics.SimpleCounter
 	TopoLoader                             topology.LoaderMetrics
 	DRKeySecretValueQueriesTotal           *prometheus.CounterVec
 	DRKeyLevel1QueriesTotal                *prometheus.CounterVec

--- a/gateway/metrics.go
+++ b/gateway/metrics.go
@@ -304,7 +304,7 @@ type Metrics struct {
 
 	// Scion Network Metrics
 	SCIONNetworkMetrics    snet.SCIONNetworkMetrics
-	SCMPErrors             metrics.Counter
+	SCMPErrors             metrics.SimpleCounter
 	SCIONPacketConnMetrics snet.SCIONPacketConnMetrics
 }
 

--- a/gateway/pathhealth/pathwatcher.go
+++ b/gateway/pathhealth/pathwatcher.go
@@ -68,7 +68,7 @@ type DefaultPathWatcherFactory struct {
 	// remote.
 	ProbesSendErrors func(remote addr.IA) metrics.Counter
 
-	SCMPErrors             metrics.Counter
+	SCMPErrors             metrics.SimpleCounter
 	SCIONPacketConnMetrics snet.SCIONPacketConnMetrics
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,18 +53,26 @@ import (
 // Counter describes a metric that accumulates values monotonically.
 // An example of a counter is the number of received HTTP requests.
 type Counter interface {
+	SimpleCounter
 	With(labelValues ...string) Counter
-	Add(delta float64)
 	Reset()
+}
+
+type SimpleCounter interface {
+	Add(delta float64)
 }
 
 // Gauge describes a metric that takes specific values over time.
 // An example of a gauge is the current depth of a job queue.
 type Gauge interface {
+	SimpleGauge
 	With(labelValues ...string) Gauge
+	Reset()
+}
+
+type SimpleGauge interface {
 	Set(value float64)
 	Add(delta float64)
-	Reset()
 }
 
 // Histogram describes a metric that takes repeated observations of the same
@@ -72,13 +80,17 @@ type Gauge interface {
 // typically expressed as quantiles or buckets. An example of a histogram is
 // HTTP request latencies.
 type Histogram interface {
+	SimpleHistogram
 	With(labelValues ...string) Histogram
+}
+
+type SimpleHistogram interface {
 	Observe(value float64)
 }
 
 // CounterAdd increases the passed in counter by the amount specified.
 // This is a no-op if c is nil.
-func CounterAdd(c Counter, delta float64) {
+func CounterAdd(c SimpleCounter, delta float64) {
 	if c != nil {
 		c.Add(delta)
 	}
@@ -86,7 +98,7 @@ func CounterAdd(c Counter, delta float64) {
 
 // CounterInc increases the passed in counter by 1.
 // This is a no-op if c is nil.
-func CounterInc(c Counter) {
+func CounterInc(c SimpleCounter) {
 	CounterAdd(c, 1)
 }
 
@@ -108,7 +120,7 @@ func CounterReset(c Counter) {
 
 // GaugeSet sets the passed in gauge to the value specified.
 // This is a no-op if g is nil.
-func GaugeSet(g Gauge, value float64) {
+func GaugeSet(g SimpleGauge, value float64) {
 	if g != nil {
 		g.Set(value)
 	}
@@ -116,7 +128,7 @@ func GaugeSet(g Gauge, value float64) {
 
 // GaugeSetTimestamp sets the passed gauge to the specified time stamp.
 // This is a no-op if g is nil.
-func GaugeSetTimestamp(g Gauge, ts time.Time) {
+func GaugeSetTimestamp(g SimpleGauge, ts time.Time) {
 	if g != nil {
 		g.Set(Timestamp(ts))
 	}
@@ -124,13 +136,13 @@ func GaugeSetTimestamp(g Gauge, ts time.Time) {
 
 // GaugeSetCurrentTime sets the passed gauge to the current time.
 // This is a no-op if g is nil.
-func GaugeSetCurrentTime(g Gauge) {
+func GaugeSetCurrentTime(g SimpleGauge) {
 	GaugeSetTimestamp(g, time.Now())
 }
 
 // GaugeAdd increases the passed in gauge by the amount specified.
 // This is a no-op if g is nil.
-func GaugeAdd(g Gauge, delta float64) {
+func GaugeAdd(g SimpleGauge, delta float64) {
 	if g != nil {
 		g.Add(delta)
 	}
@@ -138,7 +150,7 @@ func GaugeAdd(g Gauge, delta float64) {
 
 // GaugeInc increases the passed in gauge by 1.
 // This is a no-op if g is nil.
-func GaugeInc(g Gauge) {
+func GaugeInc(g SimpleGauge) {
 	GaugeAdd(g, 1)
 }
 
@@ -160,7 +172,7 @@ func GaugeReset(g Gauge) {
 
 // HistogramObserve adds an observation to the histogram.
 // This is a no-op if h is nil.
-func HistogramObserve(h Histogram, value float64) {
+func HistogramObserve(h SimpleHistogram, value float64) {
 	if h != nil {
 		h.Observe(value)
 	}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -27,6 +27,10 @@ func NewPromGauge(gv *prometheus.GaugeVec) Gauge {
 	return newGauge(gv)
 }
 
+func NewGauge(g prometheus.Gauge) SimpleGauge {
+	return &simpleGauge{g: g}
+}
+
 // NewPromCounter wraps a prometheus counter vector as a counter.
 // Returns nil if cv is nil.
 func NewPromCounter(cv *prometheus.CounterVec) Counter {
@@ -36,6 +40,10 @@ func NewPromCounter(cv *prometheus.CounterVec) Counter {
 	return newCounter(cv)
 }
 
+func NewCounter(c prometheus.Counter) SimpleCounter {
+	return &simpleCounter{c: c}
+}
+
 // NewPromHistogram wraps a prometheus histogram vector as a histogram.
 // Returns nil if hv is nil.
 func NewPromHistogram(hv *prometheus.HistogramVec) Histogram {
@@ -43,6 +51,10 @@ func NewPromHistogram(hv *prometheus.HistogramVec) Histogram {
 		return nil
 	}
 	return newHistogram(hv)
+}
+
+func NewHistogram(o prometheus.Observer) SimpleHistogram {
+	return &simpleHistogram{o: o}
 }
 
 // NewPromCounterFrom creates a wrapped prometheus counter.
@@ -94,6 +106,18 @@ func (lvs labelValuesSlice) With(labelValues ...string) labelValuesSlice {
 	return append(lvs, labelValues...)
 }
 
+type simpleGauge struct {
+	g prometheus.Gauge
+}
+
+func (g *simpleGauge) Set(value float64) {
+	g.g.Set(value)
+}
+
+func (g *simpleGauge) Add(delta float64) {
+	g.g.Add(delta)
+}
+
 // gauge implements Gauge, via a Prometheus GaugeVec.
 type gauge struct {
 	gv  *prometheus.GaugeVec
@@ -128,6 +152,14 @@ func newGauge(gv *prometheus.GaugeVec) *gauge {
 	return &gauge{
 		gv: gv,
 	}
+}
+
+type simpleCounter struct {
+	c prometheus.Counter
+}
+
+func (c *simpleCounter) Add(delta float64) {
+	c.c.Add(delta)
 }
 
 // counter implements Counter, via a Prometheus CounterVec.
@@ -167,6 +199,14 @@ func (c *counter) Add(delta float64) {
 // Reset deletes all metrics in this vector.
 func (c *counter) Reset() {
 	c.cv.MustCurryWith(makeLabels(c.lvs...)).Reset()
+}
+
+type simpleHistogram struct {
+	o prometheus.Observer
+}
+
+func (h *simpleHistogram) Observe(value float64) {
+	h.o.Observe(value)
 }
 
 // histogram implements Histogram via a Prometheus HistogramVec. The difference

--- a/pkg/snet/dispatcher.go
+++ b/pkg/snet/dispatcher.go
@@ -96,7 +96,7 @@ type DefaultSCMPHandler struct {
 	// handler is not called.
 	RevocationHandler RevocationHandler
 	// SCMPErrors reports the total number of SCMP Errors encountered.
-	SCMPErrors metrics.Counter
+	SCMPErrors metrics.SimpleCounter
 }
 
 func (h DefaultSCMPHandler) Handle(pkt *Packet) error {

--- a/pkg/snet/metrics/metrics.go
+++ b/pkg/snet/metrics/metrics.go
@@ -50,12 +50,12 @@ func NewSCIONNetworkMetrics(opts ...Option) snet.SCIONNetworkMetrics {
 	auto := promauto.With(o.registry)
 
 	return snet.SCIONNetworkMetrics{
-		Dials: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+		Dials: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_dials_total",
-			Help: "Total number of Dial calls."}, []string{})),
-		Listens: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of Dial calls."})),
+		Listens: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_listens_total",
-			Help: "Total number of Listen calls."}, []string{})),
+			Help: "Total number of Listen calls."})),
 	}
 }
 
@@ -63,36 +63,36 @@ func NewSCIONPacketConnMetrics(opts ...Option) snet.SCIONPacketConnMetrics {
 	o := apply(opts)
 	auto := promauto.With(o.registry)
 	return snet.SCIONPacketConnMetrics{
-		Closes: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+		Closes: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_closes_total",
-			Help: "Total number of Close calls."}, []string{})),
-		ReadBytes: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of Close calls."})),
+		ReadBytes: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_read_total_bytes",
-			Help: "Total number of bytes read"}, []string{})),
-		ReadPackets: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of bytes read"})),
+		ReadPackets: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_read_total_pkts",
-			Help: "Total number of packetes read"}, []string{})),
-		WriteBytes: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of packetes read"})),
+		WriteBytes: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_write_total_bytes",
-			Help: "Total number of bytes written"}, []string{})),
-		WritePackets: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of bytes written"})),
+		WritePackets: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_write_total_pkts",
-			Help: "Total number of packets written"}, []string{})),
-		DispatcherErrors: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of packets written"})),
+		DispatcherErrors: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_dispatcher_error_total",
-			Help: "Total number of dispatcher errors"}, []string{})),
-		ParseErrors: metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+			Help: "Total number of dispatcher errors"})),
+		ParseErrors: metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 			Name: "lib_snet_parse_error_total",
-			Help: "Total number of parse errors"}, []string{})),
+			Help: "Total number of parse errors"})),
 		SCMPErrors: NewSCMPErrors(opts...),
 	}
 }
 
-func NewSCMPErrors(opts ...Option) metrics.Counter {
+func NewSCMPErrors(opts ...Option) metrics.SimpleCounter {
 	o := apply(opts)
 	auto := promauto.With(o.registry)
 
-	return metrics.NewPromCounter(auto.NewCounterVec(prometheus.CounterOpts{
+	return metrics.NewCounter(auto.NewCounter(prometheus.CounterOpts{
 		Name: "lib_snet_scmp_error_total",
-		Help: "Total number of SCMP errors"}, []string{}))
+		Help: "Total number of SCMP errors"}))
 }

--- a/pkg/snet/packet_conn.go
+++ b/pkg/snet/packet_conn.go
@@ -85,21 +85,21 @@ type SCIONAddress = addr.Addr
 
 type SCIONPacketConnMetrics struct {
 	// Closes records the total number of Close calls on the connection.
-	Closes metrics.Counter
+	Closes metrics.SimpleCounter
 	// ReadBytes records the total number of bytes read on the connection.
-	ReadBytes metrics.Counter
+	ReadBytes metrics.SimpleCounter
 	// WriteBytes records the total number of bytes written on the connection.
-	WriteBytes metrics.Counter
+	WriteBytes metrics.SimpleCounter
 	// ReadPackets records the total number of packets read on the connection.
-	ReadPackets metrics.Counter
+	ReadPackets metrics.SimpleCounter
 	// WritePackets records the total number of packets written on the connection.
-	WritePackets metrics.Counter
+	WritePackets metrics.SimpleCounter
 	// ParseErrors records the total number of parse errors encountered.
-	ParseErrors metrics.Counter
+	ParseErrors metrics.SimpleCounter
 	// SCMPErrors records the total number of SCMP Errors encountered.
-	SCMPErrors metrics.Counter
+	SCMPErrors metrics.SimpleCounter
 	// DispatcherErrors records the number of dispatcher errors encountered.
-	DispatcherErrors metrics.Counter
+	DispatcherErrors metrics.SimpleCounter
 }
 
 // SCIONPacketConn gives applications full control over the content of valid SCION

--- a/pkg/snet/snet.go
+++ b/pkg/snet/snet.go
@@ -56,9 +56,9 @@ var _ Network = (*SCIONNetwork)(nil)
 
 type SCIONNetworkMetrics struct {
 	// Dials records the total number of Dial calls received by the network.
-	Dials metrics.Counter
+	Dials metrics.SimpleCounter
 	// Listens records the total number of Listen calls received by the network.
-	Listens metrics.Counter
+	Listens metrics.SimpleCounter
 }
 
 // SCIONNetwork is the SCION networking context.


### PR DESCRIPTION
Introduce simple version of the pkg/metrics objects. The simpler versions don't have a With method. The With version can have quite some overhead if used in a hot path. For now the simple counters are used in snet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/6)
<!-- Reviewable:end -->
