### PR TITLE
private/app/flag: improve error handling when resolving SCION environment

### DIFF
--- a/demo/drkey/main.go
+++ b/demo/drkey/main.go
@@ -100,7 +100,13 @@ func realMain() int {
 		DstHost: clientAddr.Host.IP.String(),
 	}
 
-	daemon, err := daemon.NewService(scionEnv.Daemon()).Connect(ctx)
+	daemonAddr, err := scionEnv.Daemon()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error resolving SCION environment:", err)
+		return 2
+	}
+
+	daemon, err := daemon.NewService(daemonAddr).Connect(ctx)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Error dialing SCION Daemon:", err)
 		return 1

--- a/private/app/flag/env.go
+++ b/private/app/flag/env.go
@@ -196,12 +196,14 @@ func (e *SCIONEnvironment) Daemon() (string, error) {
 
 	// Priority 3: Environment configuration file
 	if e.fileLoaded {
-		ases := make([]addr.IA, 0, len(e.file.ASes))
-		{
+		// Collect the ASes that are present in the environment file.
+		ases := func() []addr.IA {
+			ases := make([]addr.IA, 0, len(e.file.ASes))
 			for ia := range e.file.ASes {
 				ases = append(ases, ia)
 			}
 			slices.Sort(ases)
+			return ases
 		}
 
 		// Check if --isd-as flag is set
@@ -212,11 +214,11 @@ func (e *SCIONEnvironment) Daemon() (string, error) {
 				return as.DaemonAddress, nil
 			case ok:
 				return "", serrors.New("isd-as has no daemon configured in environment file",
-					"isd-as", e.ia, "file", e.filepath, "available", ases,
+					"isd-as", e.ia, "file", e.filepath, "available", ases(),
 				)
 			default:
 				return "", serrors.New("isd-as not found in environment file",
-					"isd-as", e.ia, "file", e.filepath, "available", ases,
+					"isd-as", e.ia, "file", e.filepath, "available", ases(),
 				)
 			}
 		}
@@ -229,11 +231,11 @@ func (e *SCIONEnvironment) Daemon() (string, error) {
 				return as.DaemonAddress, nil
 			case ok:
 				return "", serrors.New("default isd-as has no daemon configured in environment file",
-					"isd-as", ia, "file", e.filepath, "available", ases,
+					"isd-as", ia, "file", e.filepath, "available", ases(),
 				)
 			default:
 				return "", serrors.New("default isd-as not found in environment file",
-					"isd-as", ia, "file", e.filepath, "available", ases,
+					"isd-as", ia, "file", e.filepath, "available", ases(),
 				)
 			}
 		}
@@ -256,7 +258,7 @@ func (e *SCIONEnvironment) Daemon() (string, error) {
 		default:
 			return "", serrors.New("multiple ASes in environment file but no default ISD-AS set",
 				"file", e.filepath,
-				"available", ases,
+				"available", ases(),
 				"hint", "use --isd-as flag to select the local AS")
 		}
 	}

--- a/private/app/flag/env.go
+++ b/private/app/flag/env.go
@@ -20,6 +20,7 @@ import (
 	"io/fs"
 	"net/netip"
 	"os"
+	"slices"
 	"sync"
 
 	"github.com/spf13/pflag"
@@ -86,6 +87,7 @@ type SCIONEnvironment struct {
 	localFlag  *pflag.Flag
 	file       env.SCION
 	filepath   string
+	fileLoaded bool
 
 	mtx sync.Mutex
 }
@@ -128,7 +130,11 @@ func (e *SCIONEnvironment) LoadExternalVars() error {
 // from the environment file are not considered.
 func (e *SCIONEnvironment) loadFile() error {
 	if e.filepath == "" {
-		e.filepath = defaultEnvironmentFile
+		file := defaultEnvironmentFile
+		if f := os.Getenv("SCION_ENVIRONMENT_FILE"); f != "" {
+			file = f
+		}
+		e.filepath = file
 	}
 
 	raw, err := os.ReadFile(e.filepath)
@@ -142,6 +148,7 @@ func (e *SCIONEnvironment) loadFile() error {
 	if err := json.Unmarshal(raw, &e.file); err != nil {
 		return serrors.Wrap("parsing file", err)
 	}
+	e.fileLoaded = true
 	return nil
 }
 
@@ -167,26 +174,95 @@ func (e *SCIONEnvironment) loadEnv() error {
 // the following sources with the precedence as listed:
 //  1. Command line flag
 //  2. Environment variable
-//  3. Environment configuration file
-//  4. Default value.
-func (e *SCIONEnvironment) Daemon() string {
+//  3. Environment configuration file with defaultIA or --isd-as flag
+//  4. Default value (only if nothing is set).
+//
+// If no defaultIA is set but there is only one AS in the file, use that AS's daemon address.
+// If no defaultIA is set but there are multiple ASes in the file, return an error.
+// If --isd-as is set but the AS does not exist in the file, return an error.
+func (e *SCIONEnvironment) Daemon() (string, error) {
 	e.mtx.Lock()
 	defer e.mtx.Unlock()
 
+	// Priority 1: Command line flag
 	if e.sciondFlag != nil && e.sciondFlag.Changed {
-		return e.sciondFlag.Value.String()
+		return e.sciondFlag.Value.String(), nil
 	}
+
+	// Priority 2: Environment variable
 	if e.sciondEnv != nil {
-		return *e.sciondEnv
+		return *e.sciondEnv, nil
 	}
-	ia := e.file.General.DefaultIA
-	if e.iaFlag != nil && e.iaFlag.Changed {
-		ia = e.ia
+
+	// Priority 3: Environment configuration file
+	if e.fileLoaded {
+		ases := make([]addr.IA, 0, len(e.file.ASes))
+		{
+			for ia := range e.file.ASes {
+				ases = append(ases, ia)
+			}
+			slices.Sort(ases)
+		}
+
+		// Check if --isd-as flag is set
+		if e.iaFlag != nil && e.iaFlag.Changed {
+			as, ok := e.file.ASes[e.ia]
+			switch {
+			case as.DaemonAddress != "":
+				return as.DaemonAddress, nil
+			case ok:
+				return "", serrors.New("isd-as has no daemon configured in environment file",
+					"isd-as", e.ia, "file", e.filepath, "available", ases,
+				)
+			default:
+				return "", serrors.New("isd-as not found in environment file",
+					"isd-as", e.ia, "file", e.filepath, "available", ases,
+				)
+			}
+		}
+
+		// Check if default IA is set in the file
+		if ia := e.file.General.DefaultIA; !ia.IsZero() {
+			as, ok := e.file.ASes[ia]
+			switch {
+			case as.DaemonAddress != "":
+				return as.DaemonAddress, nil
+			case ok:
+				return "", serrors.New("default isd-as has no daemon configured in environment file",
+					"isd-as", ia, "file", e.filepath, "available", ases,
+				)
+			default:
+				return "", serrors.New("default isd-as not found in environment file",
+					"isd-as", ia, "file", e.filepath, "available", ases,
+				)
+			}
+		}
+
+		// No defaultIA set, check how many ASes are in the file
+		switch len(e.file.ASes) {
+		case 1:
+			for ia, as := range e.file.ASes {
+				if as.DaemonAddress != "" {
+					return as.DaemonAddress, nil
+				}
+				return "", serrors.New("only isd-as in environment file has no daemon configured",
+					"isd-as", ia, "file", e.filepath,
+				)
+			}
+		case 0:
+			return "", serrors.New("no isd-as configured in environment file",
+				"file", e.filepath,
+			)
+		default:
+			return "", serrors.New("multiple ASes in environment file but no default ISD-AS set",
+				"file", e.filepath,
+				"available", ases,
+				"hint", "use --isd-as flag to select the local AS")
+		}
 	}
-	if as, ok := e.file.ASes[ia]; ok && as.DaemonAddress != "" {
-		return as.DaemonAddress
-	}
-	return defaultDaemon
+
+	// Priority 4: Default value (only if nothing is set)
+	return defaultDaemon, nil
 }
 
 // Local returns the loca IP to listen on. The value is loaded from one of the

--- a/private/app/flag/env_test.go
+++ b/private/app/flag/env_test.go
@@ -75,6 +75,7 @@ func TestSCIONEnvironment(t *testing.T) {
 		daemon     string
 		dispatcher string
 		local      netip.Addr
+		daemonErr  bool
 	}{
 		"no flag, no file, no env, defaults only": {
 			flags:  noFlags,
@@ -128,8 +129,115 @@ func TestSCIONEnvironment(t *testing.T) {
 			tc.env(t)
 			tc.file(t, &env)
 			require.NoError(t, env.LoadExternalVars())
-			assert.Equal(t, tc.daemon, env.Daemon())
+			daemonAddr, err := env.Daemon()
+			if tc.daemonErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.daemon, daemonAddr)
+			}
 			assert.Equal(t, tc.local, env.Local())
+		})
+	}
+}
+
+func TestSCIONEnvironmentMultipleASes(t *testing.T) {
+	setupFileSingleAS := func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+		f, err := os.CreateTemp(t.TempDir(), "env.json")
+		require.NoError(t, err)
+		fName := f.Name()
+		t.Cleanup(func() { os.Remove(fName) })
+		e := env.SCION{
+			// No DefaultIA set
+			ASes: map[addr.IA]env.AS{
+				addr.MustParseIA("1-ff00:0:110"): {
+					DaemonAddress: "scion_single:1234",
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(f).Encode(e))
+		require.NoError(t, f.Close())
+		envFlags.SetFilePath(fName)
+	}
+
+	setupFileMultipleASes := func(t *testing.T, envFlags *flag.SCIONEnvironment) {
+		f, err := os.CreateTemp(t.TempDir(), "env.json")
+		require.NoError(t, err)
+		fName := f.Name()
+		t.Cleanup(func() { os.Remove(fName) })
+		e := env.SCION{
+			// No DefaultIA set
+			ASes: map[addr.IA]env.AS{
+				addr.MustParseIA("1-ff00:0:110"): {
+					DaemonAddress: "scion_as1:1234",
+				},
+				addr.MustParseIA("1-ff00:0:120"): {
+					DaemonAddress: "scion_as2:1234",
+				},
+			},
+		}
+		require.NoError(t, json.NewEncoder(f).Encode(e))
+		require.NoError(t, f.Close())
+		envFlags.SetFilePath(fName)
+	}
+
+	setupFlagNonExistentAS := func(t *testing.T, fs *pflag.FlagSet) {
+		err := fs.Parse([]string{"--isd-as", "1-ff00:0:999"})
+		require.NoError(t, err)
+	}
+
+	setupFlagExistingAS := func(t *testing.T, fs *pflag.FlagSet) {
+		err := fs.Parse([]string{"--isd-as", "1-ff00:0:110"})
+		require.NoError(t, err)
+	}
+
+	noFlags := func(t *testing.T, fs *pflag.FlagSet) {
+		require.NoError(t, fs.Parse([]string{}))
+	}
+
+	testCases := map[string]struct {
+		flags     func(t *testing.T, fs *pflag.FlagSet)
+		file      func(t *testing.T, envFlags *flag.SCIONEnvironment)
+		daemon    string
+		daemonErr bool
+	}{
+		"single AS in file, no defaultIA": {
+			flags:  noFlags,
+			file:   setupFileSingleAS,
+			daemon: "scion_single:1234",
+		},
+		"multiple ASes in file, no defaultIA, error": {
+			flags:     noFlags,
+			file:      setupFileMultipleASes,
+			daemonErr: true,
+		},
+		"multiple ASes in file, --isd-as set to existing AS": {
+			flags:  setupFlagExistingAS,
+			file:   setupFileMultipleASes,
+			daemon: "scion_as1:1234",
+		},
+		"--isd-as set to non-existent AS, error": {
+			flags:     setupFlagNonExistentAS,
+			file:      setupFileMultipleASes,
+			daemonErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			var env flag.SCIONEnvironment
+			fs := pflag.NewFlagSet("testSet", pflag.ContinueOnError)
+			env.Register(fs)
+			tc.flags(t, fs)
+			tc.file(t, &env)
+			require.NoError(t, env.LoadExternalVars())
+			daemonAddr, err := env.Daemon()
+			if tc.daemonErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.daemon, daemonAddr)
+			}
 		})
 	}
 }

--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -267,7 +267,10 @@ The template is expressed in JSON. A valid example:
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
 			localIP := net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", daemonAddr,

--- a/scion-pki/certs/request.go
+++ b/scion-pki/certs/request.go
@@ -117,7 +117,10 @@ by specifying the \--out flag.`,
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
 			localIP := net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", daemonAddr,

--- a/scion/cmd/scion/address.go
+++ b/scion/cmd/scion/address.go
@@ -58,7 +58,10 @@ case, the host could have multiple SCION addresses.
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
 
 			cmd.SilenceUsage = true
 			ctx, cancelF := context.WithTimeout(cmd.Context(), time.Second)

--- a/scion/cmd/scion/ping.go
+++ b/scion/cmd/scion/ping.go
@@ -131,7 +131,10 @@ On other errors, ping will exit with code 2.
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
 			localIP := net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", daemonAddr,

--- a/scion/cmd/scion/showpaths.go
+++ b/scion/cmd/scion/showpaths.go
@@ -98,7 +98,11 @@ On other errors, showpaths will exit with code 2.
 				return err
 			}
 
-			flags.cfg.Daemon = envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
+			flags.cfg.Daemon = daemonAddr
 			flags.cfg.Local = net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", flags.cfg.Daemon,

--- a/scion/cmd/scion/traceroute.go
+++ b/scion/cmd/scion/traceroute.go
@@ -106,7 +106,10 @@ On other errors, traceroute will exit with code 2.
 			if err := envFlags.LoadExternalVars(); err != nil {
 				return err
 			}
-			daemonAddr := envFlags.Daemon()
+			daemonAddr, err := envFlags.Daemon()
+			if err != nil {
+				return serrors.WrapNoStack("resolving SCION environment", err)
+			}
 			localIP := net.IP(envFlags.Local().AsSlice())
 			log.Debug("Resolved SCION environment flags",
 				"daemon", daemonAddr,

--- a/tools/integration/integrationlib/common.go
+++ b/tools/integration/integrationlib/common.go
@@ -70,12 +70,16 @@ func addFlags() error {
 	if err != nil {
 		return serrors.Wrap("reading scion environment", err)
 	}
+	daemonDefault, err := envFlags.Daemon()
+	if err != nil {
+		return serrors.WrapNoStack("resolving SCION environment", err)
+	}
 	// TODO(JordiSubira): Make this flag optional and consider the same case as Unspecified
 	// if it isn't explicitly set.
 	flag.Var(&Local, "local", "(Mandatory) address to listen on")
 	flag.StringVar(&Mode, "mode", ModeClient, "Run in "+ModeClient+" or "+ModeServer+" mode")
 	flag.StringVar(&Progress, "progress", "", "Socket to write progress to")
-	flag.StringVar(&daemonAddr, "sciond", envFlags.Daemon(), "SCION Daemon address")
+	flag.StringVar(&daemonAddr, "sciond", daemonDefault, "SCION Daemon address")
 	flag.IntVar(&Attempts, "attempts", 1, "Number of attempts before giving up")
 	flag.StringVar(&logConsole, "log.console", "info", "Console logging level: debug|info|error")
 	flag.StringVar(&features, "features", "",


### PR DESCRIPTION
Previously, we would fall back to returning the default SCION daemon address, even if the user provided obviously wrong values. E.g., no --isd-as flag set, but multiple ASes in the environment file without a default.

We are a bit more strict and now only return the default if no user input is given.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/11)
<!-- Reviewable:end -->
