### PR TITLE
control: swallow internal beacon handling errors

### DIFF
--- a/control/beaconing/grpc/creation_server.go
+++ b/control/beaconing/grpc/creation_server.go
@@ -74,10 +74,13 @@ func (s SegmentCreationServer) Beacon(ctx context.Context,
 	}
 	if err := s.Handler.HandleBeacon(ctx, b, peer); err != nil {
 		if internalErr, ok := errors.AsType[*beaconing.InternalError](err); ok {
-			logger.Info("Failed to handle beacon with internal error, do not inform peer", "peer", peer, "err", internalErr.Err)
+			logger.Info("Failed to handle beacon with internal error, do not inform peer",
+				"peer", peer,
+				"err", internalErr.Err,
+			)
 			return &cppb.BeaconResponse{}, nil
 		}
-		logger.Debug("Failed to handle beacon", "peer", peer, "err", err)
+		logger.Info("Failed to handle beacon", "peer", peer, "err", err)
 		return nil, serrors.Wrap("handling beacon", err)
 	}
 	return &cppb.BeaconResponse{}, nil

--- a/control/beaconing/grpc/creation_server.go
+++ b/control/beaconing/grpc/creation_server.go
@@ -16,6 +16,7 @@ package grpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"google.golang.org/grpc/codes"
@@ -23,6 +24,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/scionproto/scion/control/beacon"
+	"github.com/scionproto/scion/control/beaconing"
 	"github.com/scionproto/scion/pkg/log"
 	"github.com/scionproto/scion/pkg/private/common"
 	"github.com/scionproto/scion/pkg/private/serrors"
@@ -71,8 +73,11 @@ func (s SegmentCreationServer) Beacon(ctx context.Context,
 		InIfID:  ingress,
 	}
 	if err := s.Handler.HandleBeacon(ctx, b, peer); err != nil {
+		if internalErr, ok := errors.AsType[*beaconing.InternalError](err); ok {
+			logger.Info("Failed to handle beacon with internal error, do not inform peer", "peer", peer, "err", internalErr.Err)
+			return &cppb.BeaconResponse{}, nil
+		}
 		logger.Debug("Failed to handle beacon", "peer", peer, "err", err)
-		// TODO(roosd): return better error with status code.
 		return nil, serrors.Wrap("handling beacon", err)
 	}
 	return &cppb.BeaconResponse{}, nil

--- a/control/beaconing/handler.go
+++ b/control/beaconing/handler.go
@@ -93,12 +93,12 @@ func (h Handler) HandleBeacon(ctx context.Context, b beacon.Beacon, peer *snet.U
 		return &InternalError{Err: err}
 	}
 	if err := h.validateASEntry(b, intf); err != nil {
-		logger.Info("Beacon validation failed", "err", err)
+		logger.Debug("Beacon validation failed", "err", err)
 		h.updateMetric(span, labels.WithResult(prom.ErrVerify), err)
 		return err
 	}
 	if err := h.verifySegment(ctx, b.Segment, peer); err != nil {
-		logger.Info("Beacon verification failed", "err", err)
+		logger.Debug("Beacon verification failed", "err", err)
 		err := serrors.Wrap("verifying beacon", err)
 		h.updateMetric(span, labels.WithResult(prom.ErrVerify), err)
 		if errors.Is(err, trust.ErrNotifyTRC) {

--- a/control/beaconing/handler.go
+++ b/control/beaconing/handler.go
@@ -16,6 +16,7 @@ package beaconing
 
 import (
 	"context"
+	"errors"
 	"net"
 	"strconv"
 
@@ -34,7 +35,18 @@ import (
 	infra "github.com/scionproto/scion/private/segment/verifier"
 	"github.com/scionproto/scion/private/topology"
 	"github.com/scionproto/scion/private/tracing"
+	"github.com/scionproto/scion/private/trust"
 )
+
+// InternalError is an error returned by the beacon handler. It indicates whether
+// the error is internal and should not be reported to the peer.
+type InternalError struct {
+	Err error
+}
+
+func (e *InternalError) Error() string { return e.Err.Error() }
+
+func (e *InternalError) Unwrap() error { return e.Err }
 
 // BeaconInserter inserts beacons into the beacon store.
 type BeaconInserter interface {
@@ -78,7 +90,7 @@ func (h Handler) HandleBeacon(ctx context.Context, b beacon.Beacon, peer *snet.U
 	if err := h.Inserter.PreFilter(b); err != nil {
 		logger.Debug("Beacon pre-filtered", "err", err)
 		h.updateMetric(span, labels.WithResult("err_prefilter"), err)
-		return err
+		return &InternalError{Err: err}
 	}
 	if err := h.validateASEntry(b, intf); err != nil {
 		logger.Info("Beacon validation failed", "err", err)
@@ -87,8 +99,12 @@ func (h Handler) HandleBeacon(ctx context.Context, b beacon.Beacon, peer *snet.U
 	}
 	if err := h.verifySegment(ctx, b.Segment, peer); err != nil {
 		logger.Info("Beacon verification failed", "err", err)
+		err := serrors.Wrap("verifying beacon", err)
 		h.updateMetric(span, labels.WithResult(prom.ErrVerify), err)
-		return serrors.Wrap("verifying beacon", err)
+		if errors.Is(err, trust.ErrNotifyTRC) {
+			return &InternalError{Err: err}
+		}
+		return err
 	}
 	stat, err := h.Inserter.InsertBeacon(ctx, b)
 	if err != nil {

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -68,6 +68,8 @@ type ConsoleConfig struct {
 	// DisableCaller stops annotating logs with the calling function's file
 	// name and line number. By default, all logs are annotated.
 	DisableCaller bool `toml:"disable_caller,omitempty"`
+	// Defines the sampling of log entries.
+	Sampling ConsoleSamplingConfig
 }
 
 // InitDefaults populates unset fields in cfg to their default values (if they
@@ -81,5 +83,28 @@ func (c *ConsoleConfig) InitDefaults() {
 	}
 	if c.StacktraceLevel == "" {
 		c.StacktraceLevel = DefaultStacktraceLevel
+	}
+	c.Sampling.InitDefaults()
+}
+
+type ConsoleSamplingConfig struct {
+	// Disabled indicates that log sampling is disabled.
+	Disabled bool
+	// Initial is the number of log entries with the same level and message that
+	// are logged in the same second before sampling. If zero, sampling starts
+	// immediately.
+	Initial *int `toml:"initial"`
+	// Thereafter is defines how many log entries with the same level and
+	// message are skipped before logging it again. If zero, all log entries
+	// after initial are dropped.
+	Thereafter *int `toml:"thereafter"`
+}
+
+func (c *ConsoleSamplingConfig) InitDefaults() {
+	if c.Initial == nil {
+		c.Initial = new(100)
+	}
+	if c.Thereafter == nil {
+		c.Thereafter = new(100)
 	}
 }

--- a/pkg/log/config.go
+++ b/pkg/log/config.go
@@ -102,7 +102,7 @@ type ConsoleSamplingConfig struct {
 
 func (c *ConsoleSamplingConfig) InitDefaults() {
 	if c.Initial == nil {
-		c.Initial = new(100)
+		c.Initial = new(10)
 	}
 	if c.Thereafter == nil {
 		c.Thereafter = new(100)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -74,6 +74,14 @@ func convertCfg(cfg ConsoleConfig) (zap.Config, error) {
 		encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 		encoderConfig.EncodeCaller = fixedCallerEncoder
 	}
+	var sampling *zap.SamplingConfig
+	if !cfg.Sampling.Disabled {
+		sampling = &zap.SamplingConfig{
+			Initial:    *cfg.Sampling.Initial,
+			Thereafter: *cfg.Sampling.Thereafter,
+		}
+
+	}
 	return zap.Config{
 		Level:             zap.NewAtomicLevelAt(level),
 		DisableStacktrace: cfg.StacktraceLevel == "none",
@@ -82,6 +90,7 @@ func convertCfg(cfg ConsoleConfig) (zap.Config, error) {
 		OutputPaths:       []string{"stderr"},
 		ErrorOutputPaths:  []string{"stderr"},
 		DisableCaller:     cfg.DisableCaller,
+		Sampling:          sampling,
 	}, nil
 }
 

--- a/private/trust/fetching_provider.go
+++ b/private/trust/fetching_provider.go
@@ -196,8 +196,9 @@ func (p FetchingProvider) NotifyTRC(ctx context.Context, id cppki.TRCID, opts ..
 		return err
 	}
 	if trc.TRC.ID.Base != id.Base {
-		p.setProviderMetric(span, trustmetrics.NotifyTRC, trustmetrics.ErrValidate, nil)
-		return serrors.New("base number mismatch", "expected", trc.TRC.ID.Base, "actual", id.Base)
+		err := serrors.New("base number mismatch", "expected", trc.TRC.ID.Base, "actual", id.Base)
+		p.setProviderMetric(span, trustmetrics.NotifyTRC, trustmetrics.ErrValidate, err)
+		return err
 	}
 	if id.Serial <= trc.TRC.ID.Serial {
 		p.setProviderMetric(span, trustmetrics.NotifyTRC, trustmetrics.Success, nil)

--- a/private/trust/verifier.go
+++ b/private/trust/verifier.go
@@ -17,6 +17,7 @@ package trust
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net"
@@ -37,6 +38,10 @@ import (
 )
 
 const defaultCacheExpiration = time.Minute
+
+var (
+	ErrNotifyTRC = errors.New("notify TRC failed")
+)
 
 // Verifier is used to verify control plane messages using the AS cert
 // stored in the database.
@@ -104,7 +109,7 @@ func (v Verifier) Verify(ctx context.Context, signedMsg *cryptopb.SignedMessage,
 	}
 	if err := v.notifyTRC(ctx, id); err != nil {
 		record(trustmetrics.ErrInternal)
-		return nil, serrors.Wrap("reporting TRC", err, "id", id)
+		return nil, serrors.JoinNoStack(ErrNotifyTRC, err, "id", id)
 	}
 	query := ChainQuery{
 		IA:           ia,


### PR DESCRIPTION
If the beacon handler faces an issue that is not the fault of the peer, e.g., a TRC in its local database is missing, we should not inform the peer about this. They cannot do anything about it, and it will just always cause the fast retry mechanism to kick in. It also causes a bogus error on the peer side, which is confusing.

fixes #4585

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/15)
<!-- Reviewable:end -->
