### PR TITLE
scion-pki: allow clock skew for certificate renewal

### DIFF
--- a/scion-pki/certs/renew.go
+++ b/scion-pki/certs/renew.go
@@ -128,6 +128,8 @@ func newRenewCmd(pather command.Pather) *cobra.Command {
 		curve      string
 		expiresIn  string
 
+		allowedSkew time.Duration
+
 		timeout  time.Duration
 		tracer   string
 		logLevel string
@@ -450,8 +452,17 @@ The template is expressed in JSON. A valid example:
 					return nil, err
 				}
 
-				// Verify certificate chain
-				verifyOptions := cppki.VerifyOptions{TRC: trcs}
+				now, skewOk := verificationTime(chain, flags.allowedSkew)
+				if skewOk {
+					printf("Certificate chain in future (%s), but within acceptable skew", time.Until(now))
+				}
+				// Verify certificate chain. Allow for clock skew: if the AS
+				// certificate's NotBefore is in the future but within the
+				// allowed skew, verify against that time instead of now.
+				verifyOptions := cppki.VerifyOptions{
+					TRC:         trcs,
+					CurrentTime: now,
+				}
 				if verifyError := cppki.VerifyChain(chain, verifyOptions); verifyError != nil {
 					suffix := "." + addr.FormatIA(ca, addr.WithFileSeparator()) + ".unverified"
 
@@ -572,6 +583,11 @@ The template is expressed in JSON. A valid example:
 	)
 	cmd.Flags().StringVar(&flags.expiresIn, "expires-in", "",
 		"Remaining time threshold for renewal",
+	)
+	cmd.Flags().DurationVar(&flags.allowedSkew, "allowed-clock-skew", 30*time.Second,
+		"Allowed clock skew between the issuing CA and the local host. If the\n"+
+			"renewed certificate's NotBefore time is in the future but within this\n"+
+			"skew, verification is performed against that time instead of now",
 	)
 	cmd.Flags().BoolVar(&flags.force, "force", false,
 		"Force overwriting existing files",
@@ -953,6 +969,23 @@ func (r svcRouter) GetUnderlay(svc addr.SVC) (*net.UDPAddr, error) {
 
 func maybeMissingTRCInGrace(trcs []*cppki.TRC) bool {
 	return len(trcs) == 1 && trcs[0].InGracePeriod(time.Now())
+}
+
+// verificationTime returns the time to use for verifying the renewed
+// certificate chain. It defaults to the current time. If the NotBefore time of
+// the AS certificate lies in the future, but within the allowed clock skew, the
+// NotBefore time is returned instead. This allows for clock skew between the
+// issuing CA and the local host.
+func verificationTime(chain []*x509.Certificate, allowedSkew time.Duration) (n time.Time, skewOk bool) {
+	now := time.Now()
+	if len(chain) == 0 {
+		return now, false
+	}
+	notBefore := chain[0].NotBefore
+	if notBefore.After(now) && notBefore.Sub(now) <= allowedSkew {
+		return notBefore, true
+	}
+	return now, false
 }
 
 func createRenewalRequest(

--- a/scion-pki/certs/request.go
+++ b/scion-pki/certs/request.go
@@ -47,6 +47,8 @@ func newRequestCmd(pather command.Pather) *cobra.Command {
 		ca       []string
 		remotes  []string
 
+		allowedSkew time.Duration
+
 		timeout  time.Duration
 		tracer   string
 		logLevel string
@@ -228,8 +230,18 @@ by specifying the \--out flag.`,
 					printErr("Sending request failed: %s\n", err)
 					return nil, err
 				}
-				// Verify certificate chain
-				verifyOptions := cppki.VerifyOptions{TRC: trcs}
+
+				now, skewOk := verificationTime(chain, flags.allowedSkew)
+				if skewOk {
+					printf("Certificate chain in future (%s), but within acceptable skew", time.Until(now))
+				}
+				// Verify certificate chain. Allow for clock skew: if the AS
+				// certificate's NotBefore is in the future but within the
+				// allowed skew, verify against that time instead of now.
+				verifyOptions := cppki.VerifyOptions{
+					TRC:         trcs,
+					CurrentTime: now,
+				}
 				if verifyError := cppki.VerifyChain(chain, verifyOptions); verifyError != nil {
 					printErr("Verification failed: %s\n", verifyError)
 					// Output helpful info in case the TRC is in grace period.
@@ -302,6 +314,11 @@ by specifying the \--out flag.`,
 			"The address is of the form <ISD-AS>,<IP>. --remote can be specified multiple times\n"+
 			"and all specified remotes are tried in order until success or all of them failed.\n"+
 			"--remote is mutually exclusive with --ca.",
+	)
+	cmd.Flags().DurationVar(&flags.allowedSkew, "allowed-clock-skew", 30*time.Second,
+		"Allowed clock skew between the issuing CA and the local host. If the\n"+
+			"renewed certificate's NotBefore time is in the future but within this\n"+
+			"skew, verification is performed against that time instead of now",
 	)
 	cmd.Flags().DurationVar(&flags.timeout, "timeout", 10*time.Second,
 		"The timeout for the renewal request per CA",


### PR DESCRIPTION
Allow for up to 30 seconds clock skew when requesting certificates. If the certificate chain is issued less than 30 seconds in the future, it is still accepted and written to disk.

The services will anyway only pick it up once it becomes active from the perspective of the service

fixes https://github.com/scionproto/scion/issues/4942

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/os-scion/16)
<!-- Reviewable:end -->
